### PR TITLE
Debian add build deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,11 @@ Maintainer: Bruce Leidl <bruce@subgraph.com>
 Build-Depends: debhelper (>= 9),
                dh-golang,
                dh-systemd,
-               golang-go
+               golang-go,
+               libcairo2-dev,
+               libglib2.0-dev,
+               libgtk-3-dev,
+               libnetfilter-queue-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/subgraph/fw-daemon
 Vcs-Git: https://github.com/subgraph/fw-daemon.git


### PR DESCRIPTION
Without these changes I can't build fw-daemon in a clean pbuilder chroot. Not sure how you do it usually, but whatever :)
