### PR TITLE
Fix panic when a .desktop file has an empty Exec= line

### DIFF
--- a/sgfw/icons.go
+++ b/sgfw/icons.go
@@ -67,7 +67,7 @@ func loadDesktopFile(path string) {
 		} else if len(line) > 0 && line[0] == '[' {
 			inDE = false
 		}
-		if inDE && strings.HasPrefix(line, "Exec=") {
+		if inDE && len(line) > 5 && strings.HasPrefix(line, "Exec=") {
 			exec = strings.Fields(line[5:])[0]
 		}
 		if inDE && strings.HasPrefix(line, "Icon=") {


### PR DESCRIPTION
This PR fixes a fw-daemon panic which occurs if any `.desktop` file in `/usr/applications` doesn't have a value for the `Exec=` line. This bug was breaking the install of the firewall daemon on my Debian system.

```
Jun 28 23:03:56 localhost fw-daemon[19695]: panic: runtime error: index out of range
Jun 28 23:03:56 localhost fw-daemon[19695]: goroutine 1 [running]:
Jun 28 23:03:56 localhost fw-daemon[19695]: panic(0x55f26ef214c0, 0xc82000a030)
Jun 28 23:03:56 localhost fw-daemon[19695]: #011/usr/lib/go-1.6/src/runtime/panic.go:481 +0x3e6
Jun 28 23:03:56 localhost fw-daemon[19695]: github.com/subgraph/fw-daemon/sgfw.loadDesktopFile(0xc820436340, 0x32)
Jun 28 23:03:56 localhost fw-daemon[19695]: #011/home/user/go/src/github.com/subgraph/fw-daemon/sgfw/icons.go:73 +0x888
Jun 28 23:03:56 localhost fw-daemon[19695]: github.com/subgraph/fw-daemon/sgfw.initIcons()
Jun 28 23:03:56 localhost fw-daemon[19695]: #011/home/user/go/src/github.com/subgraph/fw-daemon/sgfw/icons.go:48 +0x837
Jun 28 23:03:56 localhost fw-daemon[19695]: github.com/subgraph/fw-daemon/sgfw.entryForPath(0xc8203fe000, 0x2a, 0xc8203fe000)
Jun 28 23:03:56 localhost fw-daemon[19695]: #011/home/user/go/src/github.com/subgraph/fw-daemon/sgfw/icons.go:21 +0x25
Jun 28 23:03:56 localhost fw-daemon[19695]: github.com/subgraph/fw-daemon/sgfw.(*Firewall).policyForPath(0xc820142680, 0xc8203fe000, 0x2a, 0xc8204b4000)
Jun 28 23:03:56 localhost fw-daemon[19695]: #011/home/user/go/src/github.com/subgraph/fw-daemon/sgfw/policy.go:93 +0x119
Jun 28 23:03:56 localhost fw-daemon[19695]: github.com/subgraph/fw-daemon/sgfw.(*Firewall).PolicyForPath(0xc820142680, 0xc8203fe000, 0x2a, 0x0)
Jun 28 23:03:56 localhost fw-daemon[19695]: #011/home/user/go/src/github.com/subgraph/fw-daemon/sgfw/policy.go:84 +0x95
Jun 28 23:03:56 localhost fw-daemon[19695]: github.com/subgraph/fw-daemon/sgfw.(*Firewall).filterPacket(0xc820142680, 0xc8203300c0)
Jun 28 23:03:56 localhost fw-daemon[19695]: #011/home/user/go/src/github.com/subgraph/fw-daemon/sgfw/policy.go:284 +0x694
Jun 28 23:03:56 localhost fw-daemon[19695]: github.com/subgraph/fw-daemon/sgfw.(*Firewall).runFilter(0xc820142680)
Jun 28 23:03:56 localhost fw-daemon[19695]: #011/home/user/go/src/github.com/subgraph/fw-daemon/sgfw/sgfw.go:98 +0x14d
Jun 28 23:03:56 localhost fw-daemon[19695]: github.com/subgraph/fw-daemon/sgfw.Main()
Jun 28 23:03:56 localhost fw-daemon[19695]: #011/home/user/go/src/github.com/subgraph/fw-daemon/sgfw/sgfw.go:144 +0x58a
Jun 28 23:03:56 localhost fw-daemon[19695]: main.main()
```