### PR TITLE
Fix mono-sgen paxrat problem

### DIFF
--- a/debian/build-hooks/H01paxrat_mono-sgen
+++ b/debian/build-hooks/H01paxrat_mono-sgen
@@ -3,5 +3,5 @@
 
 apt-get install -y --force-yes paxrat
 apt-get install -y --force-yes mono-runtime-sgen
-paxrat /usr/bin/mono-sgen
+paxrat
 apt-get install -yf

--- a/debian/build-hooks/H01paxrat_mono-sgen
+++ b/debian/build-hooks/H01paxrat_mono-sgen
@@ -1,0 +1,7 @@
+#!/bin/sh
+# paxrat /usr/bin/mono-sgen before building environment to prevent build failure
+
+apt-get install -y --force-yes paxrat
+apt-get install -y --force-yes mono-runtime-sgen
+paxrat /usr/bin/mono-sgen
+apt-get install -yf

--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -11,6 +11,8 @@ upstream-tag = v%(version)s
 overlay = True
 export-dir = /tmp/build-area
 upstream-tree = TAG
+pbuilder = True
+pbuilder-options = --hookdir ./debian/build-hooks
 
 [dch]
 debian-branch = debian


### PR DESCRIPTION
Fixes build failing without manual intervention due to `mono-sgen` running as a dependency and failing due to missing PAX flags

Requires https://github.com/subgraph/subgraph-debian-packages/pull/5